### PR TITLE
Avoid URISyntaxException caused by @iot.nextLink with $filter

### DIFF
--- a/src/main/java/de/fraunhofer/iosb/ilt/sta/jackson/EntityListDeserializer.java
+++ b/src/main/java/de/fraunhofer/iosb/ilt/sta/jackson/EntityListDeserializer.java
@@ -15,9 +15,12 @@ import de.fraunhofer.iosb.ilt.sta.model.Entity;
 import de.fraunhofer.iosb.ilt.sta.model.EntityType;
 import de.fraunhofer.iosb.ilt.sta.model.ext.EntityList;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.Iterator;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,8 +77,16 @@ public class EntityListDeserializer<T extends Entity<T>> extends StdDeserializer
 
 			if (node.has("@iot.nextLink")) {
 				try {
-					URI nextLink = new URI(node.get("@iot.nextLink").asText());
-					entities.setNextLink(nextLink);
+				    // 
+				    // we can always expect 2 tokens
+				    String token[] = node.get("@iot.nextLink").asText().split("\\?");
+				    // the request uri (token[0]) 
+				    // the queryParameters (token[1])
+			        URIBuilder nextLinkBuilder = new URIBuilder(token[0]);
+			        // parse & add all query parameters
+			        nextLinkBuilder.addParameters(URLEncodedUtils.parse(token[1], Charset.defaultCharset()));
+			        // build the URI properly 
+					entities.setNextLink(nextLinkBuilder.build());
 				} catch (URISyntaxException e) {
 					logger.warn("@iot.nextLink field contains malformed URI", e);
 				}


### PR DESCRIPTION
According to the SensorThings specs [1] for filtering, the $filter statement **may contain spaces** eg. 

> http://myhost/v1.0/Datastreams$filter=observationType eq 'http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement'

When using the SensorThingsClient API with a $filter statement, the resulting URI gets the additional parameter properly added by using URIBuilder in Query's list() method. The result is, that the $filter statement is properly encoded before executing the request. 

No problem so far, however - the **potential** error comes up when deserializing the search result. In that case, the "@iot.nextLink" may again contain the spaces which raise a URISyntaxExeption in the EntityListDeserializer. 

[1] http://docs.opengeospatial.org/is/15-078r6/15-078r6.html#55
